### PR TITLE
Update libmpdclient submodule url & fix playlists popup menu position

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libmpdclient"]
 	path = Frameworks/libmpdclient
-	url = git://git.musicpd.org/master/libmpdclient.git
+	url = https://github.com/MusicPlayerDaemon/libmpdclient.git
 [submodule "imeji"]
 	path = Frameworks/imeji
 	url = https://github.com/arttuperala/imeji.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Fixed kmbmpdc crashing when no cover art is supplied.
+- Fixed playlist menu positioning.
 
 ### Changed
 - Cover art scaling mechanism now produces two image representations, one for Retina displays and one for non-Retina displays.

--- a/kmbmpdc/Controller.swift
+++ b/kmbmpdc/Controller.swift
@@ -208,7 +208,9 @@ class Controller: NSViewController {
             let menuItem = NSMenuItem(title: playlist, action: selector, keyEquivalent: "")
             playlistMenu.addItem(menuItem)
         }
-        playlistMenu.popUp(positioning: nil, at: sender.frame.origin, in: sender)
+        // Under the playlist button
+        let point = NSPoint(x: 0, y: sender.frame.height)
+        playlistMenu.popUp(positioning: nil, at: point, in: sender)
     }
 
     @IBAction func previousWasClicked(_ sender: NSButton) {


### PR DESCRIPTION
The libmpdclient repository has moved to Github, and the playlist popup was being displayed relative to itself (way off to the right of the player). This fixes both of those problems!

Thanks for the great player!